### PR TITLE
Upgrade `actions/*` versions to latest in action

### DIFF
--- a/.github/actions/setup-codeql-environment/action.yml
+++ b/.github/actions/setup-codeql-environment/action.yml
@@ -449,20 +449,20 @@ runs:
 
     - name: Setup Python (with cache)
       if: inputs.install-language-runtimes == 'true' && contains(inputs.languages, 'python') && steps.check-deps.outputs.python-deps == 'true'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
         cache: "pip"
 
     - name: Setup Python (without cache)
       if: inputs.install-language-runtimes == 'true' && contains(inputs.languages, 'python') && steps.check-deps.outputs.python-deps == 'false'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Setup Java (with cache)
       if: inputs.install-language-runtimes == 'true' && contains(inputs.languages, 'java') && steps.check-deps.outputs.java-deps == 'true'
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: "temurin"
         java-version: ${{ inputs.java-version }}
@@ -470,21 +470,21 @@ runs:
 
     - name: Setup Java (without cache)
       if: inputs.install-language-runtimes == 'true' && contains(inputs.languages, 'java') && steps.check-deps.outputs.java-deps == 'false'
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: "temurin"
         java-version: ${{ inputs.java-version }}
 
     - name: Setup Go (with cache)
       if: inputs.install-language-runtimes == 'true' && contains(inputs.languages, 'go') && steps.check-deps.outputs.go-deps == 'true'
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }}
         cache: true
 
     - name: Setup Go (without cache)
       if: inputs.install-language-runtimes == 'true' && contains(inputs.languages, 'go') && steps.check-deps.outputs.go-deps == 'false'
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }}
         cache: false
@@ -505,7 +505,7 @@ runs:
 
     - name: Setup .NET (for C#)
       if: inputs.install-language-runtimes == 'true' && contains(inputs.languages, 'csharp')
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
 


### PR DESCRIPTION
**Dependency updates for language setup actions:**

* Updated `actions/setup-python` from v5 to v6 for both cached and non-cached Python setup steps.
* Updated `actions/setup-java` from v4 to v5 for both cached and non-cached Java setup steps.
* Updated `actions/setup-go` from v5 to v6 for both cached and non-cached Go setup steps.
* Updated `actions/setup-dotnet` from v4 to v5 for .NET (C#) setup step.